### PR TITLE
Nemesis Deck View

### DIFF
--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -12,6 +12,7 @@ import type {
 	ActionMagnetResponse,
 	ActionPlayHand,
 	ActionReceiveEndGameJokersRequest,
+	ActionReceiveNemesisDeckRequest,
 	ActionRemovePhantom,
 	ActionSendPhantom,
 	ActionSetAnte,
@@ -373,6 +374,23 @@ const receiveEndGameJokersAction = ({ keys }: ActionHandlerArgs<ActionReceiveEnd
 	})
 }
 
+const getNemesisDeckAction = (client: Client) => {
+	const [lobby, enemy] = getEnemy(client)
+	if (!lobby || !enemy) return;
+	enemy.sendAction({
+		action: "getNemesisDeck"
+	})
+}
+
+const receiveNemesisDeckAction = ({ cards }: ActionHandlerArgs<ActionReceiveNemesisDeckRequest>, client: Client) => {
+	const [lobby, enemy] = getEnemy(client)
+	if (!lobby || !enemy) return;
+	enemy.sendAction({
+		action: "receiveNemesisDeck",
+		cards
+	})
+}
+
 const startAnteTimerAction = ({ time }: ActionHandlerArgs<ActionStartAnteTimer>, client: Client) => {
 	const [lobby, enemy] = getEnemy(client)
 	if (!lobby || !enemy) return;
@@ -440,6 +458,8 @@ export const actionHandlers = {
 	magnetResponse: magnetResponseAction,
 	getEndGameJokers: getEndGameJokersAction,
 	receiveEndGameJokers: receiveEndGameJokersAction,
+	getNemesisDeck: getNemesisDeckAction,
+	receiveNemesisDeck: receiveNemesisDeckAction,
 	startAnteTimer: startAnteTimerAction,
 	failTimer: failTimerAction,
 	syncClient: syncClientAction,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -52,6 +52,8 @@ export type ActionMagnet = { action: 'magnet' }
 export type ActionMagnetResponse = { action: 'magnetResponse', key: string }
 export type ActionGetEndGameJokersRequest = { action: 'getEndGameJokers' }
 export type ActionReceiveEndGameJokersRequest = { action: 'receiveEndGameJokers', keys: string }
+export type ActionGetNemesisDeckRequest = { action: 'getNemesisDeck' }
+export type ActionReceiveNemesisDeckRequest = { action: 'receiveNemesisDeck', cards: string }
 export type ActionStartAnteTimer = { action: 'startAnteTimer', time: number }
 export type ActionServerToClient =
 	| ActionConnected
@@ -83,6 +85,8 @@ export type ActionServerToClient =
 	| ActionMagnetResponse
 	| ActionGetEndGameJokersRequest
 	| ActionReceiveEndGameJokersRequest
+	| ActionGetNemesisDeckRequest
+	| ActionReceiveNemesisDeckRequest
 	| ActionStartAnteTimer
 // Client to Server
 export type ActionUsername = { action: 'username'; username: string; modHash: string }
@@ -120,6 +124,8 @@ export type ActionMagnetRequest = { action: 'magnet' }
 export type ActionMagnetResponseRequest = { action: 'magnetResponse', key: string }
 export type ActionGetEndGameJokersResponse = { action: 'getEndGameJokers' }
 export type ActionReceiveEndGameJokersResponse = { action: 'receiveEndGameJokers', keys: string }
+export type ActionGetNemesisDeckResponse = { action: 'getNemesisDeck' }
+export type ActionReceiveNemesisDeckResponse = { action: 'receiveNemesisDeck', cards: string }
 export type ActionStartAnteTimerRequest = { action: 'startAnteTimer', time: number }
 export type ActionFailTimer = { action: 'failTimer' }
 export type ActionSyncClient = { action: 'syncClient', isCached: boolean }
@@ -155,6 +161,8 @@ export type ActionClientToServer =
 	| ActionMagnetResponseRequest
 	| ActionGetEndGameJokersResponse
 	| ActionReceiveEndGameJokersResponse
+	| ActionGetNemesisDeckResponse
+	| ActionReceiveNemesisDeckResponse
 	| ActionStartAnteTimerRequest
 	| ActionFailTimer
 	| ActionSyncClient

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import type {
 	ActionMagnetResponse,
 	ActionPlayHand,
 	ActionReceiveEndGameJokersRequest,
+	ActionReceiveNemesisDeckRequest,
 	ActionRemovePhantom,
 	ActionSendPhantom,
 	ActionServerToClient,
@@ -293,6 +294,15 @@ const server = createServer((socket) => {
 					case 'receiveEndGameJokers':
 						actionHandlers.receiveEndGameJokers(
 							actionArgs as ActionHandlerArgs<ActionReceiveEndGameJokersRequest>,
+							client,
+						)
+						break
+					case 'getNemesisDeck':
+						actionHandlers.getNemesisDeck(client)
+						break
+					case 'receiveNemesisDeck':
+						actionHandlers.receiveNemesisDeck(
+							actionArgs as ActionHandlerArgs<ActionReceiveNemesisDeckRequest>,
 							client,
 						)
 						break


### PR DESCRIPTION
While on one of 'You Win' or 'Game Over' screens, a 'View Nemesis Deck' button is added that allows the player to view their opponent's full deck.

With regards to network action handlers, this feature is implemented in a similar fashion to how the end game jokers are received.