### PR TITLE
Add furthestBlind, a new client object attribute for Survival Mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .vscode
 releases
+.vs

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ setAnte: ante
 - Declares the current ante that the client is on to the server, this needs to be handled by the server on a per-client basis since clients can be on different antes at the same time
 - ante: The ante to set the client to on the server side
 
+---
+
+setFurthestBlind: furthestBlind
+- Declares the furthest blind the client has beaten to the server
+- furthestBlind: The number to set the client's furthest blind to on the server side
+
 ### Utility
 
 keepAlive

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -30,7 +30,8 @@ class Client {
 	score = new InsaneInt(0, 0, 0)
 	handsLeft = 4
 	ante = 1
-	skips = 0
+    skips = 0
+    furthest_blind = 0
 
 	livesBlocker = false
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -30,8 +30,8 @@ class Client {
 	score = new InsaneInt(0, 0, 0)
 	handsLeft = 4
 	ante = 1
-    skips = 0
-    furthest_blind = 0
+	skips = 0
+	furthestBlind = 0
 
 	livesBlocker = false
 

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -168,11 +168,15 @@ class Lobby {
 			this.host.isReady = false;
 			this.host.resetBlocker();
 			this.host.setLocation("Blind Select");
+			this.host.furthestBlind = 0;
+			this.host.skips = 0;
 		}
 		if (this.guest) {
 			this.guest.isReady = false;
 			this.guest.resetBlocker();
 			this.guest.setLocation("Blind Select");
+			this.guest.furthestBlind = 0;
+			this.guest.skips = 0;
 		}
 	}
 }

--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -203,7 +203,7 @@ const lobbyOptionsAction = (
 };
 
 const failRoundAction = (client: Client) => {
-	const lobby = client.lobby;
+    const [lobby, enemy] = getEnemy(client)
 
 	if (!lobby) return;
 
@@ -212,18 +212,22 @@ const failRoundAction = (client: Client) => {
 	}
 
 	if (client.lives === 0) {
-		let gameLoser = null;
-		let gameWinner = null;
-		if (client.id === lobby.host?.id) {
-			gameLoser = lobby.host;
-			gameWinner = lobby.guest;
-		} else {
-			gameLoser = lobby.guest;
-			gameWinner = lobby.host;
-		}
+		if (lobby.gameMode !== 'survival') {
+			let gameLoser = null;
+			let gameWinner = null;
+			if (client.id === lobby.host?.id) {
+				gameLoser = lobby.host;
+				gameWinner = lobby.guest;
+			} else {
+				gameLoser = lobby.guest;
+				gameWinner = lobby.host;
+			}
 
-		gameWinner?.sendAction({ action: "winGame" });
-		gameLoser?.sendAction({ action: "loseGame" });
+			gameWinner?.sendAction({ action: "winGame" });
+			gameLoser?.sendAction({ action: "loseGame" });
+        } else {
+            
+        }
 	}
 };
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -197,4 +197,4 @@ export type ActionHandlers = {
 export type ActionHandlerArgs<T extends HandledActions> = Omit<T, 'action'>
 
 // Other types
-export type GameMode = 'attrition' | 'showdown'
+export type GameMode = 'attrition' | 'showdown' | 'survival'

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -117,6 +117,7 @@ export type ActionSetAnte = {
 export type ActionVersion = { action: 'version'; version: string }
 export type ActionSetLocation = { action: 'setLocation'; location: string }
 export type ActionNewRound = { action: 'newRound' }
+export type ActionSetFurthestBlind = { action: 'setFurthestBlind', furthestBlind: number}
 export type ActionSkip = { action: 'skip', skips: number }
 export type ActionLetsGoGamblingNemesisRequest = { action: 'letsGoGamblingNemesis' }
 export type ActionEatPizzaRequest = { action: 'eatPizza', whole: boolean }
@@ -152,6 +153,7 @@ export type ActionClientToServer =
 	| ActionVersion
 	| ActionSetLocation
 	| ActionNewRound
+	| ActionSetFurthestBlind
 	| ActionSkip
 	| ActionSendPhantom
 	| ActionRemovePhantom

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import type {
 	ActionServerToClient,
 	ActionSetAnte,
 	ActionSetLocation,
+	ActionSetFurthestBlind,
 	ActionSkip,
 	ActionSpentLastShop,
 	ActionStartAnteTimer,
@@ -238,6 +239,12 @@ const server = createServer((socket) => {
 					case 'setAnte':
 						actionHandlers.setAnte(
 							actionArgs as ActionHandlerArgs<ActionSetAnte>,
+							client,
+						)
+						break
+					case 'setFurthestBlind':
+						actionHandlers.setFurthestBlind(
+							actionArgs as ActionHandlerArgs<ActionSetFurthestBlind>,
 							client,
 						)
 						break


### PR DESCRIPTION
`furthestBlind` is number, where the last digit represents the small/big/boss blind, and the remaining digits represents the ante. For example, `furthestBlind` equals to 211 means the player has defeated the small blind of ante 21, and 83 means they has defeated the boss blind of ante 8.

This pull request also adds the relevant actions and functions to `furthestBlind`, which are similar to `Client.ante`.
`setFurthestBlindAction` and `failRoundAction` defines the relevant losing and winning conditions for Survival Mode.

`setFurthestBlind: furthestBlind`
- Declares the furthest blind the client has beaten to the server
- furthestBlind: The number to set the client's furthest blind to on the server side.

Also fix skips carrying over to the next game in the same lobby.

This is related to https://github.com/Balatro-Multiplayer/BalatroMultiplayer/pull/160.