### PR TITLE
Handy's MP Extension actions implementation

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -36,6 +36,7 @@ class Lobby {
 	// biome-ignore lint/suspicious/noExplicitAny:
 	options: { [key: string]: any };
 	tcgBets: Map<string, number>;
+    handyAllowMPExtension: Map<string, boolean>;
 
 	// Attrition is the default game mode
 	constructor(host: Client, gameMode: GameMode = "attrition") {
@@ -49,6 +50,7 @@ class Lobby {
 		this.gameMode = gameMode;
 		this.options = {};
 		this.tcgBets = new Map();
+        this.handyAllowMPExtension = new Map();
 
 		host.setLobby(this);
 		host.isReadyLobby = false;
@@ -75,6 +77,8 @@ class Lobby {
 		if (this.host === null) {
 			Lobbies.delete(this.code);
 		} else {
+            this.handyAllowMPExtension.delete(client.id)
+
 			// TODO: Refactor for more than 2 players
 			// Stop game if someone leaves
 			this.broadcastAction({ action: "stopGame" });
@@ -96,6 +100,7 @@ class Lobby {
 
 		client.setLobby(this);
 		client.isReadyLobby = false;
+        this.handyAllowMPExtension.set(client.id, false)
 		client.sendAction({
 			action: "joinedLobby",
 			code: this.code,
@@ -134,6 +139,11 @@ class Lobby {
 		// Should only sent true to the host
 		action.isHost = true;
 		this.host.sendAction(action);
+
+        this.broadcastAction({
+            action: "handyMPExtensionLobbyEnabled",
+            enabled: Array.from(this.handyAllowMPExtension.values()).every(Boolean)
+        })
 	};
 
 	setPlayersLives = (lives: number) => {

--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -30,6 +30,8 @@ import type {
 	ActionTcgBet,
 	ActionTcgPlayerStatusRequest,
 	ActionTcgEndTurn,
+    ActionHandyMPExtensionEnable,
+    ActionHandyMPExtensionDisable,
 } from "./actions.js";
 import { generateSeed } from "./utils.js";
 
@@ -702,6 +704,26 @@ const tcgEndTurnAction = (
 	});
 };
 
+const handyMPExtensionEnable = (
+    args: ActionHandlerArgs<ActionHandyMPExtensionEnable>,
+    client: Client,
+) => {
+    if (!client.lobby) return
+
+    client.lobby.handyAllowMPExtension.set(client.id, true)
+    client.lobby.broadcastLobbyInfo()
+}
+
+const handyMPExtensionDisable = (
+    args: ActionHandlerArgs<ActionHandyMPExtensionDisable>,
+    client: Client,
+) => {
+    if (!client.lobby) return
+
+    client.lobby.handyAllowMPExtension.set(client.id, false)
+    client.lobby.broadcastLobbyInfo()
+}
+
 export const actionHandlers = {
 	username: usernameAction,
 	createLobby: createLobbyAction,
@@ -749,4 +771,6 @@ export const actionHandlers = {
 	tcgBet: tcgBetAction,
 	tcgPlayerStatus: tcgPlayerStatusAction,
 	tcgEndTurn: tcgEndTurnAction,
+    handyMPExtensionEnable: handyMPExtensionEnable,
+    handyMPExtensionDisable: handyMPExtensionDisable,
 } satisfies Partial<ActionHandlers>;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -59,6 +59,8 @@ export type ActionGetNemesisStatsRequest = { action: 'endGameStatsRequested' }
 export type ActionReceiveNemesisStatsRequest = { action: 'nemesisEndGameStats', reroll_count: string, reroll_cost_total:string, vouchers:string }
 export type ActionStartAnteTimer = { action: 'startAnteTimer', time: number }
 export type ActionPauseAnteTimer = { action: 'pauseAnteTimer', time: number }
+// Handy Actions (Server to Client)
+export type ActionHandyMPExtensionLobbyEnabled = { action: 'handyMPExtensionLobbyEnabled', enabled: boolean }
 // TCG Actions (Server to Client)
 export type ActionTcgCompatible = { action: 'tcg_compatible' }
 export type ActionTcgStartGame = { action: 'tcgStartGame', damage: number, starting: boolean }
@@ -104,6 +106,7 @@ export type ActionServerToClient =
 	| ActionTcgStartGame
 	| ActionTcgPlayerStatus
 	| ActionTcgStartTurn
+    | ActionHandyMPExtensionLobbyEnabled
 // Client to Server
 export type ActionUsername = { action: 'username'; username: string; modHash: string }
 export type ActionCreateLobby = { action: 'createLobby'; gameMode: GameMode }
@@ -157,6 +160,9 @@ export type ActionStartTcgBetting = { action: 'startTcgBetting' }
 export type ActionTcgBet = { action: 'tcgBet', bet: number }
 export type ActionTcgPlayerStatusRequest = { action: 'tcgPlayerStatus', [key: string]: unknown }
 export type ActionTcgEndTurn = { action: 'tcgEndTurn', [key: string]: unknown }
+// Handy Actions (Client to Server)
+export type ActionHandyMPExtensionEnable = { action: 'handyMPExtensionEnable', [key: string]: unknown }
+export type ActionHandyMPExtensionDisable = { action: 'handyMPExtensionDisable', [key: string]: unknown }
 export type ActionClientToServer =
 	| ActionUsername
 	| ActionCreateLobby
@@ -205,6 +211,8 @@ export type ActionClientToServer =
 	| ActionTcgBet
 	| ActionTcgPlayerStatusRequest
 	| ActionTcgEndTurn
+    | ActionHandyMPExtensionEnable
+    | ActionHandyMPExtensionDisable
 // Utility actions
 export type ActionKeepAlive = { action: 'keepAlive' }
 export type ActionKeepAliveAck = { action: 'keepAliveAck' }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,8 @@ import type {
 	ActionTcgBet,
 	ActionTcgPlayerStatusRequest,
 	ActionTcgEndTurn,
+    ActionHandyMPExtensionEnable,
+    ActionHandyMPExtensionDisable,
 } from './actions.js'
 import { InsaneInt } from './InsaneInt.js'
 
@@ -379,6 +381,18 @@ const server = createServer((socket) => {
 					case 'tcgEndTurn':
 						actionHandlers.tcgEndTurn(
 							actionArgs as ActionHandlerArgs<ActionTcgEndTurn>,
+							client,
+						)
+						break
+					case 'handyMPExtensionEnable':
+						actionHandlers.handyMPExtensionEnable(
+							actionArgs as ActionHandlerArgs<ActionHandyMPExtensionEnable>,
+							client,
+						)
+						break
+					case 'handyMPExtensionDisable':
+						actionHandlers.handyMPExtensionDisable(
+							actionArgs as ActionHandlerArgs<ActionHandyMPExtensionDisable>,
 							client,
 						)
 						break


### PR DESCRIPTION
This PR adds actions needed to sync up state used for determining is all players in lobby enable Multiplayer Extension from Handy, which allows to use previously banned controls such as Speed Multiplier and Animation Skip in MP lobby, but only if ALL players in it enable it.
This means, speedup will not work if any player decide to disable it.
When player join, by default value is false, and then client sync it with own value taken from config.
Configs such as max speed in lobby handled by `MP.LOBBY.config`