### PR TITLE
fix(seed): expand seed length from 5 to 8 — 45M was a speed bump, not a wall

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-export function generateSeed(length = 5) {
+export function generateSeed(length = 8) {
 	let result = ''
 	const characters = 'ABCDEFGHIJKLMNPQRSTUVWXYZ123456789'
 	const charactersLength = characters.length


### PR DESCRIPTION
### Why

The seed alphabet is 34 characters (A-Z minus O, 1-9). At length 5, that's ~45 million possible seeds. Turns out that's searchable on a single CPU in under 10 seconds. No GPU required, no cleverness needed — just enumerate and check.

In practice this means someone watching a stream can snipe the seed before players reach PvP. Not a theoretical attack; a practical one with a trivial script.

Credit to @small-skittle for pointing out the obvious thing nobody noticed.

### What this does

Bumps the default seed length from 5 to 8 characters. Same alphabet, same generation logic. Search space goes from ~4.5×10⁷ to ~1.8×10¹². 

### What it doesn't do

Switch to a CSPRNG, or change the alphabet.

### Test plan

- [ ] New seeds are 8 characters
- [ ] Existing game flows accept the longer seed without truncation or UI breakage
- [ ] Confirm client-side seed display handles 8 chars