### PR TITLE
fix(reconnect): preserve game state across disconnects

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -101,6 +101,14 @@ class Client {
 	setSkips = (skips: number) => {
 		this.skips = skips
 	}
+
+	/** Adopt the connection from another Client (used on reconnect) */
+	replaceConnection = (other: Client) => {
+		this.address = other.address
+		this.sendAction = other.sendAction
+		this.closeConnection = other.closeConnection
+		this.reconnectToken = other.reconnectToken
+	}
 }
 
 export default Client

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -1,6 +1,5 @@
 import type Client from "./Client.js";
 import GameModes from "./GameMode.js";
-import { InsaneInt } from "./InsaneInt.js";
 import type {
 	ActionLobbyInfo,
 	ActionServerToClient,
@@ -32,24 +31,10 @@ export const getEnemy = (client: Client): [Lobby | null, Client | null] => {
 /** How long to keep a disconnected player's slot reserved (ms) */
 const RECONNECT_GRACE_PERIOD = 60000;
 
-interface DisconnectedGameState {
-	lives: number;
-	score: InsaneInt;
-	handsLeft: number;
-	ante: number;
-	skips: number;
-	furthestBlind: number;
-	livesBlocker: boolean;
-	isReady: boolean;
-	firstReady: boolean;
-	location: string;
-}
-
 interface DisconnectedSlot {
-	reconnectToken: string;
+	client: Client;
 	role: 'host' | 'guest';
 	timer: ReturnType<typeof setTimeout>;
-	gameState: DisconnectedGameState;
 }
 
 class Lobby {
@@ -145,20 +130,8 @@ class Lobby {
 		console.log(`Player ${client.id} disconnected from lobby ${this.code}, reserving slot for ${RECONNECT_GRACE_PERIOD / 1000}s`)
 
 		this.disconnectedSlot = {
-			reconnectToken: client.reconnectToken,
+			client,
 			role,
-			gameState: {
-				lives: client.lives,
-				score: new InsaneInt(client.score.startingECount, client.score.coefficient, client.score.exponent),
-				handsLeft: client.handsLeft,
-				ante: client.ante,
-				skips: client.skips,
-				furthestBlind: client.furthestBlind,
-				livesBlocker: client.livesBlocker,
-				isReady: client.isReady,
-				firstReady: client.firstReady,
-				location: client.location,
-			},
 			timer: setTimeout(() => {
 				// Grace period expired, do a full leave
 				console.log(`Reconnect grace period expired for lobby ${this.code}`)
@@ -179,44 +152,37 @@ class Lobby {
 		enemy?.sendAction({ action: "enemyDisconnected" });
 	};
 
-	/** Reconnecting client reclaims their slot */
-	rejoin = (newClient: Client, reconnectToken: string): boolean => {
-		if (!this.disconnectedSlot || this.disconnectedSlot.reconnectToken !== reconnectToken) {
-			return false;
+	/** Reconnecting client reclaims their slot.
+	 *  Returns the restored Client (with all game state intact) on success, or null on failure.
+	 *  The caller MUST use the returned client for all future messages on this socket. */
+	rejoin = (newClient: Client, reconnectToken: string): Client | null => {
+		if (!this.disconnectedSlot || this.disconnectedSlot.client.reconnectToken !== reconnectToken) {
+			return null;
 		}
 
-		const { role, timer, gameState } = this.disconnectedSlot;
+		const { client: oldClient, role, timer } = this.disconnectedSlot;
 		clearTimeout(timer);
 		this.disconnectedSlot = null;
 
-		// Restore game state from the disconnected client
-		newClient.lives = gameState.lives;
-		newClient.score = new InsaneInt(gameState.score.startingECount, gameState.score.coefficient, gameState.score.exponent);
-		newClient.handsLeft = gameState.handsLeft;
-		newClient.ante = gameState.ante;
-		newClient.skips = gameState.skips;
-		newClient.furthestBlind = gameState.furthestBlind;
-		newClient.livesBlocker = gameState.livesBlocker;
-		newClient.isReady = gameState.isReady;
-		newClient.firstReady = gameState.firstReady;
-		newClient.location = gameState.location;
+		// Swap the new socket/connection onto the old client, preserving all game state
+		oldClient.replaceConnection(newClient);
 
-		// Place the new client in the correct slot
+		// Place the old client back in the correct slot
 		if (role === 'host') {
-			this.host = newClient;
+			this.host = oldClient;
 		} else {
-			this.guest = newClient;
+			this.guest = oldClient;
 		}
 
-		newClient.setLobby(this);
-		this.handyAllowMPExtension.set(newClient.id, false);
+		oldClient.setLobby(this);
+		this.handyAllowMPExtension.set(oldClient.id, false);
 
 		// Send rejoin confirmation with new reconnect token
-		newClient.sendAction({
+		oldClient.sendAction({
 			action: "rejoinedLobby",
 			code: this.code,
 			type: this.gameMode,
-			reconnectToken: newClient.reconnectToken,
+			reconnectToken: oldClient.reconnectToken,
 		});
 
 		// Notify the other player
@@ -224,17 +190,17 @@ class Lobby {
 		enemy?.sendAction({ action: "enemyReconnected" });
 
 		// Re-sync game state so both sides have correct values
-		newClient.sendAction({ action: "playerInfo", lives: newClient.lives });
+		oldClient.sendAction({ action: "playerInfo", lives: oldClient.lives });
 		enemy?.sendAction({
 			action: "enemyInfo",
-			handsLeft: newClient.handsLeft,
-			score: newClient.score.toString(),
-			skips: newClient.skips,
-			lives: newClient.lives,
+			handsLeft: oldClient.handsLeft,
+			score: oldClient.score.toString(),
+			skips: oldClient.skips,
+			lives: oldClient.lives,
 		});
 
 		this.broadcastLobbyInfo();
-		return true;
+		return oldClient;
 	};
 
 	join = (client: Client) => {

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -1,5 +1,6 @@
 import type Client from "./Client.js";
 import GameModes from "./GameMode.js";
+import { InsaneInt } from "./InsaneInt.js";
 import type {
 	ActionLobbyInfo,
 	ActionServerToClient,
@@ -31,10 +32,24 @@ export const getEnemy = (client: Client): [Lobby | null, Client | null] => {
 /** How long to keep a disconnected player's slot reserved (ms) */
 const RECONNECT_GRACE_PERIOD = 60000;
 
+interface DisconnectedGameState {
+	lives: number;
+	score: InsaneInt;
+	handsLeft: number;
+	ante: number;
+	skips: number;
+	furthestBlind: number;
+	livesBlocker: boolean;
+	isReady: boolean;
+	firstReady: boolean;
+	location: string;
+}
+
 interface DisconnectedSlot {
 	reconnectToken: string;
 	role: 'host' | 'guest';
 	timer: ReturnType<typeof setTimeout>;
+	gameState: DisconnectedGameState;
 }
 
 class Lobby {
@@ -132,6 +147,18 @@ class Lobby {
 		this.disconnectedSlot = {
 			reconnectToken: client.reconnectToken,
 			role,
+			gameState: {
+				lives: client.lives,
+				score: new InsaneInt(client.score.startingECount, client.score.coefficient, client.score.exponent),
+				handsLeft: client.handsLeft,
+				ante: client.ante,
+				skips: client.skips,
+				furthestBlind: client.furthestBlind,
+				livesBlocker: client.livesBlocker,
+				isReady: client.isReady,
+				firstReady: client.firstReady,
+				location: client.location,
+			},
 			timer: setTimeout(() => {
 				// Grace period expired, do a full leave
 				console.log(`Reconnect grace period expired for lobby ${this.code}`)
@@ -158,9 +185,21 @@ class Lobby {
 			return false;
 		}
 
-		const { role, timer } = this.disconnectedSlot;
+		const { role, timer, gameState } = this.disconnectedSlot;
 		clearTimeout(timer);
 		this.disconnectedSlot = null;
+
+		// Restore game state from the disconnected client
+		newClient.lives = gameState.lives;
+		newClient.score = new InsaneInt(gameState.score.startingECount, gameState.score.coefficient, gameState.score.exponent);
+		newClient.handsLeft = gameState.handsLeft;
+		newClient.ante = gameState.ante;
+		newClient.skips = gameState.skips;
+		newClient.furthestBlind = gameState.furthestBlind;
+		newClient.livesBlocker = gameState.livesBlocker;
+		newClient.isReady = gameState.isReady;
+		newClient.firstReady = gameState.firstReady;
+		newClient.location = gameState.location;
 
 		// Place the new client in the correct slot
 		if (role === 'host') {
@@ -183,6 +222,16 @@ class Lobby {
 		// Notify the other player
 		const enemy = role === 'host' ? this.guest : this.host;
 		enemy?.sendAction({ action: "enemyReconnected" });
+
+		// Re-sync game state so both sides have correct values
+		newClient.sendAction({ action: "playerInfo", lives: newClient.lives });
+		enemy?.sendAction({
+			action: "enemyInfo",
+			handsLeft: newClient.handsLeft,
+			score: newClient.score.toString(),
+			skips: newClient.skips,
+			lives: newClient.lives,
+		});
 
 		this.broadcastLobbyInfo();
 		return true;

--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -84,7 +84,7 @@ const disconnectFromLobbyAction = (client: Client) => {
 const rejoinLobbyAction = (
 	{ code, reconnectToken }: ActionHandlerArgs<ActionRejoinLobby>,
 	client: Client,
-) => {
+): Client | undefined => {
 	const lobby = Lobby.get(code);
 	if (!lobby) {
 		client.sendAction({
@@ -94,12 +94,15 @@ const rejoinLobbyAction = (
 		return;
 	}
 
-	if (!lobby.rejoin(client, reconnectToken)) {
+	const restoredClient = lobby.rejoin(client, reconnectToken);
+	if (!restoredClient) {
 		client.sendAction({
 			action: "error",
 			message: "Could not rejoin lobby. Token invalid or slot expired.",
 		});
+		return;
 	}
+	return restoredClient;
 };
 
 const lobbyInfoAction = (client: Client) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,7 @@ const server = createServer((socket) => {
 	// Enable OS-level TCP keepalive as secondary dead connection detection
 	socket.setKeepAlive(true, 10000)
 
-	const client = new Client(socket.address(), sendActionToSocket(socket), socket.end)
+	let client = new Client(socket.address(), sendActionToSocket(socket), socket.end)
 	client.sendAction({ action: 'connected' })
 	client.sendAction({ action: 'version' })
 
@@ -205,12 +205,14 @@ const server = createServer((socket) => {
 							client,
 						)
 						break
-					case 'rejoinLobby':
-						actionHandlers.rejoinLobby(
+					case 'rejoinLobby': {
+						const restored = actionHandlers.rejoinLobby(
 							actionArgs as ActionHandlerArgs<ActionRejoinLobby>,
 							client,
 						)
+						if (restored) client = restored
 						break
+					}
 					case 'lobbyInfo':
 						actionHandlers.lobbyInfo(client)
 						break


### PR DESCRIPTION
> [!WARNING]
> This has not been tested yet. Needs manual verification before merging.

### Why

When a player's TCP connection drops mid-game, the server creates a 60-second grace period for reconnection. The reconnect slot stored the player's token and role. It did not store anything about the game.

On reconnect, a fresh `Client` object is created by the socket handler — `lives = 5`, `score = 0`, `ante = 1`, the full factory-default experience. The rejoin logic slotted this blank client into the lobby without transferring any state from the old one. The server then authoritatively told both players the wrong life count on the next PvP resolution.

Observed in the wild: player at 1 life disconnects, reconnects, server thinks they have 5. They lose a PvP round. Server sends `playerInfo lives: 4`. Three bonus lives, on the house.

### What this does

Instead of storing just a token in the `DisconnectedSlot`, the server now keeps the entire old `Client` object. On rejoin, `oldClient.replaceConnection(newClient)` swaps the socket onto the original client — all game state survives by construction, not by copying a field list that someone has to remember to maintain.

`main.ts` reassigns its `client` binding to the restored object so all future messages on that socket route to the right place. `rejoin()` returns the restored client (or `null` on failure) instead of a boolean. After reconnection, both sides get an immediate `playerInfo`/`enemyInfo` re-sync.

Four files touched: `Client.ts`, `Lobby.ts`, `actionHandlers.ts`, `main.ts`.

### Test plan

- [ ] Player disconnects mid-game, reconnects within 60s — lives, score, ante, skips all match pre-disconnect values
- [ ] Opponent sees correct enemy lives after the reconnect (not 5, not the default)
- [ ] Reconnect token expiry (60s) still triggers a full leave
- [ ] Voluntary leave (not a disconnect) still works normally
- [ ] Double disconnect/reconnect in quick succession doesn't corrupt state