### PR TITLE
fix: add include to tsconfig.json so tsc compiles source files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,5 +35,6 @@
 		/* Completeness */
 		"skipDefaultLibCheck": true /* Skip type checking .d.ts files that are included with TypeScript. */,
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */
-	}
+	},
+	"include": ["src"]
 }


### PR DESCRIPTION
Hello! I recently encountered a problem where building with tsc doesn't work without an include configuration. Sorry if I'm missing something and wasting your time.