### PR TITLE
Adjustments for PvP timer

### DIFF
--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -186,7 +186,11 @@ const readyBlindAction = (client: Client) => {
 		client.lobby.host.handsLeft = 4;
 		client.lobby.guest.handsLeft = 4;
 
-		client.lobby.broadcastAction({ action: "startBlind" });
+        let firstPlayer: "host" | "guest" | undefined
+        if (client.lobby.host.firstReady) firstPlayer = "host"
+        if (client.lobby.guest.firstReady) firstPlayer = "guest"
+
+		client.lobby.broadcastAction({ action: "startBlind", firstPlayer });
 	}
 };
 
@@ -266,6 +270,53 @@ const playHandAction = (
 		});
 	}
 };
+
+const failPvPTimerAction = (
+	client: Client,
+) => {
+    const lobby = client.lobby;
+
+	client.loseLife();
+
+	if (!lobby) return;
+
+    if (client.lives === 0) {
+		let gameLoser = null;
+		let gameWinner = null;
+		if (client.id === lobby.host?.id) {
+			gameLoser = lobby.host;
+			gameWinner = lobby.guest;
+		} else {
+			gameLoser = lobby.guest;
+			gameWinner = lobby.host;
+		}
+
+		gameWinner?.sendAction({ action: "winGame" });
+		gameLoser?.sendAction({ action: "loseGame" });
+	} else {
+        let roundWinner: Client
+        let roundLoser: Client
+        if (client.id === lobby.host?.id) {
+            roundWinner = lobby.guest!;
+            roundLoser = lobby.host!;
+        } else {
+            roundWinner = lobby.host!;
+            roundLoser = lobby.guest!;
+        }
+        roundWinner.firstReady = false;
+		roundLoser.firstReady = false;
+		roundWinner.sendAction({
+            action: "endPvP",
+            lost: false,
+            pvpTimerLost: true
+        });
+		roundLoser.sendAction({
+			action: "endPvP",
+			lost: true,
+            pvpTimerLost: true
+		});
+    }
+}
 
 const stopGameAction = (client: Client) => {
 	if (!client.lobby) {
@@ -833,6 +884,7 @@ export const actionHandlers = {
 	moddedAction: moddedAction,
 	handyMPExtensionEnable: handyMPExtensionEnable,
 	handyMPExtensionDisable: handyMPExtensionDisable,
+    failPvPTimer: failPvPTimerAction,
 } satisfies Partial<ActionHandlers>;
 
 /** Server-internal handler for connection drops (not a client action) */

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -23,7 +23,7 @@ export type ActionStartGame = {
 	stake?: number
 	seed?: string
 }
-export type ActionStartBlind = { action: 'startBlind' }
+export type ActionStartBlind = { action: 'startBlind', firstPlayer?: "host" | "guest" }
 export type ActionWinGame = { action: 'winGame' }
 export type ActionLoseGame = { action: 'loseGame' }
 export type ActionGameInfo = {
@@ -40,7 +40,7 @@ export type ActionEnemyInfo = {
 	skips: number
 	lives: number
 }
-export type ActionEndPvP = { action: 'endPvP'; lost: boolean }
+export type ActionEndPvP = { action: 'endPvP'; lost: boolean, pvpTimerLost?: boolean }
 export type ActionLobbyOptions = { action: 'lobbyOptions', gamemode: string }
 export type ActionRequestVersion = { action: 'version' }
 export type ActionEnemyLocation = { action: 'enemyLocation'; location: string }
@@ -162,6 +162,7 @@ export type ActionReceiveNemesisStatsResponse = { action: 'nemesisEndGameStats',
 export type ActionStartAnteTimerRequest = { action: 'startAnteTimer', time: number }
 export type ActionPauseAnteTimerRequest = { action: 'pauseAnteTimer', time: number }
 export type ActionFailTimer = { action: 'failTimer' }
+export type ActionFailPvPTimer = { action: 'failPvPTimer' }
 export type ActionSyncClient = { action: 'syncClient', isCached: boolean }
 // TCG Actions (Client to Server)
 export type ActionTcgServerVersion = { action: 'tcgServerVersion', version: number }
@@ -216,6 +217,7 @@ export type ActionClientToServer =
 	| ActionStartAnteTimerRequest
 	| ActionPauseAnteTimerRequest
 	| ActionFailTimer
+	| ActionFailPvPTimer
 	| ActionSyncClient
 	| ActionTcgServerVersion
 	| ActionStartTcgBetting

--- a/src/main.ts
+++ b/src/main.ts
@@ -360,6 +360,9 @@ const server = createServer((socket) => {
 					case 'failTimer':
 						actionHandlers.failTimer(client)
 						break
+					case 'failPvPTimer':
+						actionHandlers.failPvPTimer(client)
+						break
 					case 'syncClient':
 						actionHandlers.syncClient(
 							actionArgs as ActionHandlerArgs<ActionSyncClient>,


### PR DESCRIPTION
This PR implements some adjustments needed for proper working newly designed PvP timer:
- `startBlind` action: also sends who reached PvP first (needed to give advantage in case of stalemates)
- `endPvP` action: also sends is pvp was ended because of someone failed PvP timer (needed for deducting hands from Seltzer)
- new `failPvPTimer` action: triggered when player run out of time during pvp round. Decrement one life from player, and then does check is game should end and do it if so, otherwise, finishes pvp round