### PR TITLE
Reset per-game state on startGame to clear stale enemy skips

### DIFF
--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -139,6 +139,9 @@ const startGameAction = (client: Client) => {
 		? Number.parseInt(lobby.options.starting_lives)
 		: GameModes[lobby.gameMode].startingLives;
 
+	// resetPlayers() clears isInGame, so it must run before we set it true below.
+	lobby.resetPlayers();
+
 	lobby.isInGame = true;
 	lobby.broadcastAction({
 		action: "startGame",


### PR DESCRIPTION
When a game ended via winGame/loseGame without a stopGame round-trip, Client.skips (and furthestBlind, location, ready flags) carried into the next game, so the first enemyInfo broadcast leaked the prior game's skip count to the opponent. Call lobby.resetPlayers() at the top of startGameAction so a fresh start clears the same state that stop/leave already does.