### PR TITLE
fix(server): make it boot — both the binary and npm start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN npm run build
 
 EXPOSE 8788
 
-CMD [ "node", "dist/src/main.js" ]
+CMD [ "node", "dist/main.js" ]

--- a/src/main.ts
+++ b/src/main.ts
@@ -471,8 +471,13 @@ import { fileURLToPath } from 'node:url'
 
 const ADMIN_PORT = 8789
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const ADMIN_PUBLIC_KEY_PATH = resolve(__dirname, '..', '..', '.github', 'admin_public.pem')
+// Works under both tsc-emitted ESM (npm run start) and the esbuild CJS bundle
+// used by pkg. import.meta.url is undefined in CJS output; __dirname is
+// undefined in ESM. typeof is the only safe way to probe an undeclared name.
+const scriptDir = typeof __dirname !== 'undefined'
+	? __dirname
+	: dirname(fileURLToPath(import.meta.url))
+const ADMIN_PUBLIC_KEY_PATH = resolve(scriptDir, '..', '.github', 'admin_public.pem')
 const adminPublicKey = existsSync(ADMIN_PUBLIC_KEY_PATH)
 	? createPublicKey(readFileSync(ADMIN_PUBLIC_KEY_PATH, 'utf-8'))
 	: null

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,5 +35,6 @@
 		/* Completeness */
 		"skipDefaultLibCheck": true /* Skip type checking .d.ts files that are included with TypeScript. */,
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */
-	}
+	},
+	"include": ["src"]
 }


### PR DESCRIPTION
### Why

No way to run this server right now without fiddling.

`npm run start` pointed at `dist/main.js`, but tsc was actually emitting to `dist/src/main.js`. The reason: `build.js` (a Node script for the esbuild pipeline) sits at the repo root, so tsc inferred the repo root as `rootDir` and `build.js` got dragged in as collateral. #24 spotted this and proposed `"include": ["src"]` — the correct root-cause fix. This PR adopts that and updates the Dockerfile (which had been independently patched to `dist/src/main.js`) to match.

The pkg-compiled binaries (`server-linux`, `server-win.exe`, `server-macos`) threw `ERR_INVALID_ARG_TYPE` before binding a port. `src/main.ts` resolves the admin public key via `fileURLToPath(import.meta.url)`, but `build.js` bundles to CJS, where `import.meta.url` is `undefined`.

### What this does

- `tsconfig.json`: `"include": ["src"]` so tsc only compiles server source. Output now lands at `dist/main.js`. (Credit: #24 by @ch1kulya.)
- `src/main.ts`: probe with `typeof __dirname !== 'undefined'` before falling back to `fileURLToPath(import.meta.url)`. `__dirname` is defined in the CJS bundle; `import.meta.url` is defined in the ESM `tsc` output. `typeof` is the one reference to an undeclared identifier that doesn't throw.

### What it doesn't do

Anything else - switch the bundle format to ESM, change the pkg pipeline etc. 

Anyone running the binary just gets the existing "admin server will reject all requests" warning instead of an immediate crash.

### Test plan

- [x] `npm run build && npm run start` — boots, listens on 8788 + 127.0.0.1:8789
- [x] `npm run build-servers` + run bundle as CJS — boots, same output. (Reproduces the pkg runtime: rename `dist/bundle.js` to `.cjs` so Node ignores `"type": "module"`, then `node dist/bundle.cjs`.)
- [ ] Full `./build.sh` → run `releases/server-linux` on a Linux host