### PR TITLE
fix: stop unhandled socket errors from crashing the server

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,13 @@ const sendActionToSocket =
 			)
 		}
 
-		socket.write(`${data}\n`)
+		// Guard against the socket ending between the destroyed check and the
+		// write (race) — a throw/'error' here must not take down the server.
+		try {
+			socket.write(`${data}\n`)
+		} catch (err) {
+			console.warn('Failed to write to client socket (ignored):', (err as Error).message)
+		}
 	}
 
 const server = createServer((socket) => {
@@ -121,6 +127,13 @@ const server = createServer((socket) => {
 	socket.setNoDelay()
 	// Enable OS-level TCP keepalive as secondary dead connection detection
 	socket.setKeepAlive(true, 10000)
+
+	// A client abruptly resetting the connection emits an 'error' event
+	// (e.g. ECONNRESET from the read path); without this listener that becomes
+	// an unhandled error and crashes the whole process. Log and let it close.
+	socket.on('error', (err) => {
+		console.warn('Client connection error (ignored):', err.message)
+	})
 
 	const client = new Client(socket.address(), sendActionToSocket(socket), socket.end)
 	client.sendAction({ action: 'connected' })
@@ -587,6 +600,13 @@ const adminHandlers: Record<string, (parsed: any, socket: import('net').Socket) 
 }
 
 const adminServer = createServer((socket) => {
+	// Without this, an abrupt admin-client disconnect (ECONNRESET) or a
+	// write-after-end emits an unhandled 'error' event that crashes the whole
+	// process. Log and drop the connection instead.
+	socket.on('error', (err) => {
+		console.warn('Admin connection error (ignored):', err.message)
+	})
+
 	socket.on('data', (data) => {
 		const messages = data.toString().split('\n')
 		for (const msg of messages) {


### PR DESCRIPTION
## Problem

Accepted sockets had **no `'error'` listener** on either the client (`:8788`) or admin (`:8789`) server, and there's no global `uncaughtException` handler. Node terminates the process on an unhandled socket `'error'`, so any peer that **abruptly resets** a connection (ECONNRESET on the read path — a player's network dropping, the game being killed, flaky wi-fi) crashes the whole server, dropping **everyone** currently connected.

Graceful disconnects (TCP FIN → `'end'`/`'close'`) are fine; only abrupt RSTs trigger it — which is why it shows up as an *intermittent* crash, not a constant one.

## Fix

Add a socket `'error'` handler to both servers that logs and drops the connection.
- The **client** server binds `0.0.0.0` (every player) — this is the one that matters.
- The **admin** server binds `127.0.0.1` (localhost only), so it's low-risk insurance.
- Also wraps the per-message `socket.write` in `try/catch` as a secondary guard against a synchronous throw.

## Verification

Minimal repro: a Node `net` server with no socket `'error'` handler exits non-zero with `Unhandled 'error' event … ECONNRESET` when a client resets the connection; adding the handler makes it survive. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
